### PR TITLE
Add LoggedInUser count endpoint

### DIFF
--- a/src/Backend.Api/Api/NuxtUI/MetricsController.cs
+++ b/src/Backend.Api/Api/NuxtUI/MetricsController.cs
@@ -37,6 +37,8 @@ SessionUser _sessionUser) : ApiBaseController
 
     public readonly record struct ViewsResult(DateTime DateTime, int Views);
 
+    public readonly record struct ActiveUserCountResponse(int ActiveUserCount);
+
     [AccessOnlyAsLoggedIn]
     [HttpGet]
     public GetAllDataResponse GetAllData()
@@ -96,6 +98,16 @@ SessionUser _sessionUser) : ApiBaseController
             TodaysPrivateQuestionCreatedCount = todaysPrivateQuestionCreatedCount,
             MonthlyPrivateCreatedQuestionsOfPastYear = monthlyPrivateCreatedQuestionsOfPastYear
         };
+    }
+
+    [AccessOnlyAsLoggedIn]
+    [HttpGet]
+    public ActiveUserCountResponse GetActiveUserCount()
+    {
+        if (!_sessionUser.IsInstallationAdmin)
+            return new ActiveUserCountResponse(0);
+
+        return new ActiveUserCountResponse(LoggedInSessionStore.Count);
     }
 
     private (int todaysActiveUserCount, List<ViewsResult> dailyActiveUsersOfPastYear, List<ViewsResult> monthlyActiveUsersOfPastYear) GetActiveUserCounts()

--- a/src/Backend.Core/Web/Context/LoggedInSessionStore.cs
+++ b/src/Backend.Core/Web/Context/LoggedInSessionStore.cs
@@ -1,0 +1,22 @@
+using System.Collections.Concurrent;
+
+public static class LoggedInSessionStore
+{
+    private static readonly ConcurrentDictionary<string, int> _sessions = new();
+
+    public static void Add(string sessionId, int userId)
+    {
+        if (string.IsNullOrEmpty(sessionId))
+            return;
+        _sessions[sessionId] = userId;
+    }
+
+    public static void Remove(string sessionId)
+    {
+        if (string.IsNullOrEmpty(sessionId))
+            return;
+        _sessions.TryRemove(sessionId, out _);
+    }
+
+    public static int Count => _sessions.Count;
+}

--- a/src/Backend.Core/Web/Context/SessionUser.cs
+++ b/src/Backend.Core/Web/Context/SessionUser.cs
@@ -76,10 +76,12 @@ public class SessionUser : IRegisterAsInstancePerLifetime, ISessionUser
         if (user.IsInstallationAdmin)
             IsInstallationAdmin = true;
         _extendedUserCache.Add(user.Id, _pageViewRepo);
+        LoggedInSessionStore.Add(_httpContext.Session.Id, user.Id);
     }
 
     public void Logout()
     {
+        LoggedInSessionStore.Remove(_httpContext.Session.Id);
         IsLoggedIn = false;
         IsInstallationAdmin = false;
         _userId = -1;


### PR DESCRIPTION
## Summary
- track logged in sessions via new `LoggedInSessionStore`
- update `SessionUser` to add/remove sessions on login/logout
- adjust metrics endpoint to report live logged-in users

## Testing
- `dotnet test src/Tests/Tests.csproj -c Release` *(fails: `dotnet` not found)*