### PR TITLE
Expose live session count in Maintenance API

### DIFF
--- a/src/Backend.Api/Api/NuxtUI/MetricsController.cs
+++ b/src/Backend.Api/Api/NuxtUI/MetricsController.cs
@@ -36,7 +36,6 @@ SessionUser _sessionUser) : ApiBaseController
         List<ViewsResult> MonthlyPrivateCreatedQuestionsOfPastYear);
 
     public readonly record struct ViewsResult(DateTime DateTime, int Views);
-
     [AccessOnlyAsLoggedIn]
     [HttpGet]
     public GetAllDataResponse GetAllData()

--- a/src/Backend.Api/Api/NuxtUI/Pages/VueMaintenanceController.cs
+++ b/src/Backend.Api/Api/NuxtUI/Pages/VueMaintenanceController.cs
@@ -20,6 +20,7 @@ public class VueMaintenanceController(
     IWebHostEnvironment _webHostEnvironment) : ApiBaseController
 {
     public readonly record struct VueMaintenanceResult(bool Success, string Data);
+    public readonly record struct ActiveUserCountResponse(int ActiveUserCount);
 
     [AccessOnlyAsAdmin]
     [HttpGet]
@@ -284,6 +285,13 @@ public class VueMaintenanceController(
             Success = true,
             Data = "Started 100 test jobs."
         };
+    }
+
+    [AccessOnlyAsAdmin]
+    [HttpGet]
+    public ActiveUserCountResponse GetActiveUserCount()
+    {
+        return new ActiveUserCountResponse(LoggedInSessionStore.Count);
     }
 
     [AccessOnlyAsAdmin]

--- a/src/Backend.Core/Web/Context/LoggedInSessionStore.cs
+++ b/src/Backend.Core/Web/Context/LoggedInSessionStore.cs
@@ -1,0 +1,18 @@
+using System.Collections.Concurrent;
+
+public static class LoggedInSessionStore
+{
+    private static readonly ConcurrentDictionary<string, byte> _sessions = new();
+
+    public static void Add(string sessionId)
+    {
+        _sessions.TryAdd(sessionId, 0);
+    }
+
+    public static void Remove(string sessionId)
+    {
+        _sessions.TryRemove(sessionId, out _);
+    }
+
+    public static int Count => _sessions.Count;
+}

--- a/src/Backend.Core/Web/Context/SessionUser.cs
+++ b/src/Backend.Core/Web/Context/SessionUser.cs
@@ -68,6 +68,8 @@ public class SessionUser : IRegisterAsInstancePerLifetime, ISessionUser
 
     public void Login(User user, PageViewRepo _pageViewRepo)
     {
+        _httpContext.Session.ForceInit();
+        LoggedInSessionStore.Add(_httpContext.Session.Id);
         HasBetaAccess = true;
         IsLoggedIn = true;
         _userId = user.Id;
@@ -80,6 +82,7 @@ public class SessionUser : IRegisterAsInstancePerLifetime, ISessionUser
 
     public void Logout()
     {
+        LoggedInSessionStore.Remove(_httpContext.Session.Id);
         IsLoggedIn = false;
         IsInstallationAdmin = false;
         _userId = -1;


### PR DESCRIPTION
## Summary
- remove ActiveUserCount API from `MetricsController`
- track logged in session IDs via new `LoggedInSessionStore`
- update `SessionUser` to add/remove sessions on login/logout
- add `GetActiveUserCount` endpoint to `VueMaintenanceController`

## Testing
- `dotnet test src/Tests/Tests.csproj -c Release` *(fails: `dotnet` not found)*