### PR TITLE
Add recent session metrics to maintenance

### DIFF
--- a/src/Backend.Api/Api/NuxtUI/Pages/VueMaintenanceController.cs
+++ b/src/Backend.Api/Api/NuxtUI/Pages/VueMaintenanceController.cs
@@ -20,7 +20,7 @@ public class VueMaintenanceController(
     IWebHostEnvironment _webHostEnvironment) : ApiBaseController
 {
     public readonly record struct VueMaintenanceResult(bool Success, string Data);
-    public readonly record struct ActiveUserCountResponse(int ActiveUserCount);
+    public readonly record struct ActiveSessionsResponse(int ActiveUserCount, List<string> Sessions);
 
     [AccessOnlyAsAdmin]
     [HttpGet]
@@ -289,9 +289,11 @@ public class VueMaintenanceController(
 
     [AccessOnlyAsAdmin]
     [HttpGet]
-    public ActiveUserCountResponse GetActiveUserCount()
+    public ActiveSessionsResponse GetActiveSessions()
     {
-        return new ActiveUserCountResponse(LoggedInSessionStore.Count);
+        var sessions = LoggedInSessionStore.GetSessionsActiveWithin(TimeSpan.FromMinutes(5)).ToList();
+        var count = sessions.Count;
+        return new ActiveSessionsResponse(count, sessions);
     }
 
     [AccessOnlyAsAdmin]

--- a/src/Backend.Api/Api/NuxtUI/Pages/VueMaintenanceController.cs
+++ b/src/Backend.Api/Api/NuxtUI/Pages/VueMaintenanceController.cs
@@ -20,7 +20,8 @@ public class VueMaintenanceController(
     IWebHostEnvironment _webHostEnvironment) : ApiBaseController
 {
     public readonly record struct VueMaintenanceResult(bool Success, string Data);
-    public readonly record struct ActiveSessionsResponse(int ActiveUserCount, List<string> Sessions);
+
+    public readonly record struct ActiveSessionsResponse(int LoggedInUserCount, int AnonymousUserCount);
 
     [AccessOnlyAsAdmin]
     [HttpGet]
@@ -291,9 +292,9 @@ public class VueMaintenanceController(
     [HttpGet]
     public ActiveSessionsResponse GetActiveSessions()
     {
-        var sessions = LoggedInSessionStore.GetSessionsActiveWithin(TimeSpan.FromMinutes(5)).ToList();
-        var count = sessions.Count;
-        return new ActiveSessionsResponse(count, sessions);
+        var loggedInUserCount = LoggedInSessionStore.GetLoggedInUsersActiveWithin(TimeSpan.FromMinutes(5));
+        var anonymousCount = LoggedInSessionStore.GetAnonymousActiveWithin(TimeSpan.FromMinutes(1));
+        return new ActiveSessionsResponse(loggedInUserCount, anonymousCount);
     }
 
     [AccessOnlyAsAdmin]

--- a/src/Backend.Api/Middlewares/SessionActivityMiddleware.cs
+++ b/src/Backend.Api/Middlewares/SessionActivityMiddleware.cs
@@ -1,0 +1,15 @@
+using Microsoft.AspNetCore.Http;
+
+public class SessionActivityMiddleware(RequestDelegate _next)
+{
+    public async Task InvokeAsync(HttpContext httpContext)
+    {
+        if (httpContext.Session?.GetInt32("userId") > 0)
+        {
+            LoggedInSessionStore.Touch(httpContext.Session.Id);
+        }
+
+        await _next(httpContext);
+    }
+}
+

--- a/src/Backend.Api/Middlewares/SessionActivityMiddleware.cs
+++ b/src/Backend.Api/Middlewares/SessionActivityMiddleware.cs
@@ -6,7 +6,11 @@ public class SessionActivityMiddleware(RequestDelegate _next)
     {
         if (httpContext.Session?.GetInt32("userId") > 0)
         {
-            LoggedInSessionStore.Touch(httpContext.Session.Id);
+            LoggedInSessionStore.TouchLoggedInUsers(httpContext.Session.Id);
+        }
+        else
+        {
+            LoggedInSessionStore.TouchOrAddAnonymousUsers(httpContext.Session.Id);
         }
 
         await _next(httpContext);

--- a/src/Backend.Api/Program.cs
+++ b/src/Backend.Api/Program.cs
@@ -138,6 +138,7 @@ try
     });
 
     app.UseSession();
+    app.UseMiddleware<SessionActivityMiddleware>();
     app.UseRouting();
     app.MapControllers();
 

--- a/src/Backend.Core/Web/Context/LoggedInSessionStore.cs
+++ b/src/Backend.Core/Web/Context/LoggedInSessionStore.cs
@@ -2,16 +2,37 @@ using System.Collections.Concurrent;
 
 public static class LoggedInSessionStore
 {
-    private static readonly ConcurrentDictionary<string, byte> _sessions = new();
+    private static readonly ConcurrentDictionary<string, DateTime> _sessions = new();
 
     public static void Add(string sessionId)
     {
-        _sessions.TryAdd(sessionId, 0);
+        _sessions[sessionId] = DateTime.UtcNow;
+    }
+
+    public static void Touch(string sessionId)
+    {
+        if (_sessions.ContainsKey(sessionId))
+            _sessions[sessionId] = DateTime.UtcNow;
     }
 
     public static void Remove(string sessionId)
     {
         _sessions.TryRemove(sessionId, out _);
+    }
+
+    public static IEnumerable<string> GetSessionsActiveWithin(TimeSpan timeSpan)
+    {
+        var threshold = DateTime.UtcNow - timeSpan;
+        return _sessions
+            .Where(s => s.Value >= threshold)
+            .Select(s => s.Key)
+            .ToList();
+    }
+
+    public static int CountActiveWithin(TimeSpan timeSpan)
+    {
+        var threshold = DateTime.UtcNow - timeSpan;
+        return _sessions.Count(s => s.Value >= threshold);
     }
 
     public static int Count => _sessions.Count;

--- a/src/Backend.Core/Web/Context/LoggedInSessionStore.cs
+++ b/src/Backend.Core/Web/Context/LoggedInSessionStore.cs
@@ -29,26 +29,14 @@ public static class LoggedInSessionStore
                 _anonymousSessions.TryRemove(session.Key, out _);
     }
 
-    public static void TouchLoggedInUsers(string sessionId)
-    {
-        if (_loggedInSessions.ContainsKey(sessionId))
-            _loggedInSessions[sessionId] = DateTime.UtcNow;
-        else
-            _loggedInSessions.TryAdd(sessionId, DateTime.UtcNow);
-    }
+    public static void TouchLoggedInUsers(string sessionId) => 
+        _loggedInSessions.AddOrUpdate(sessionId, DateTime.UtcNow, (_, _) => DateTime.UtcNow);
 
-    public static void TouchOrAddAnonymousUsers(string sessionId)
-    {
-        if (_anonymousSessions.ContainsKey(sessionId))
-            _anonymousSessions[sessionId] = DateTime.UtcNow;
-        else
-            _anonymousSessions.TryAdd(sessionId, DateTime.UtcNow);
-    }
+    public static void TouchOrAddAnonymousUsers(string sessionId) => 
+        _anonymousSessions.AddOrUpdate(sessionId, DateTime.UtcNow, (_, _) => DateTime.UtcNow);
 
-    public static void Remove(string sessionId)
-    {
+    public static void Remove(string sessionId) => 
         _loggedInSessions.TryRemove(sessionId, out _);
-    }
 
     public static int GetLoggedInUsersActiveWithin(TimeSpan timeSpan)
     {

--- a/src/Backend.Core/Web/Context/LoggedInSessionStore.cs
+++ b/src/Backend.Core/Web/Context/LoggedInSessionStore.cs
@@ -1,39 +1,66 @@
 using System.Collections.Concurrent;
+using System.Timers;
 
 public static class LoggedInSessionStore
 {
-    private static readonly ConcurrentDictionary<string, DateTime> _sessions = new();
+    private static readonly ConcurrentDictionary<string, DateTime> _loggedInSessions = new();
+    private static readonly ConcurrentDictionary<string, DateTime> _anonymousSessions = new();
+    private static readonly System.Timers.Timer _cleanupTimer;
+    private const int CleanupIntervalMinutes = 5;
 
-    public static void Add(string sessionId)
+    static LoggedInSessionStore()
     {
-        _sessions[sessionId] = DateTime.UtcNow;
+        _cleanupTimer = new System.Timers.Timer(CleanupIntervalMinutes * 60 * 1000); // 10 minutes in milliseconds
+        _cleanupTimer.Elapsed += CleanupOldSessions;
+        _cleanupTimer.AutoReset = true;
+        _cleanupTimer.Start();
     }
 
-    public static void Touch(string sessionId)
+    private static void CleanupOldSessions(object? sender, ElapsedEventArgs e)
     {
-        if (_sessions.ContainsKey(sessionId))
-            _sessions[sessionId] = DateTime.UtcNow;
+        var cutoffTime = DateTime.UtcNow.AddMinutes(-CleanupIntervalMinutes);
+
+        foreach (var session in _loggedInSessions)
+            if (session.Value < cutoffTime) 
+                _loggedInSessions.TryRemove(session.Key, out _);
+
+        foreach (var session in _anonymousSessions)
+            if (session.Value < cutoffTime)
+                _anonymousSessions.TryRemove(session.Key, out _);
+    }
+
+    public static void TouchLoggedInUsers(string sessionId)
+    {
+        if (_loggedInSessions.ContainsKey(sessionId))
+            _loggedInSessions[sessionId] = DateTime.UtcNow;
+        else
+            _loggedInSessions.TryAdd(sessionId, DateTime.UtcNow);
+    }
+
+    public static void TouchOrAddAnonymousUsers(string sessionId)
+    {
+        if (_anonymousSessions.ContainsKey(sessionId))
+            _anonymousSessions[sessionId] = DateTime.UtcNow;
+        else
+            _anonymousSessions.TryAdd(sessionId, DateTime.UtcNow);
     }
 
     public static void Remove(string sessionId)
     {
-        _sessions.TryRemove(sessionId, out _);
+        _loggedInSessions.TryRemove(sessionId, out _);
     }
 
-    public static IEnumerable<string> GetSessionsActiveWithin(TimeSpan timeSpan)
+    public static int GetLoggedInUsersActiveWithin(TimeSpan timeSpan)
     {
         var threshold = DateTime.UtcNow - timeSpan;
-        return _sessions
-            .Where(s => s.Value >= threshold)
-            .Select(s => s.Key)
-            .ToList();
+        return _loggedInSessions
+            .Count(s => s.Value >= threshold);
     }
 
-    public static int CountActiveWithin(TimeSpan timeSpan)
+    public static int GetAnonymousActiveWithin(TimeSpan timeSpan)
     {
         var threshold = DateTime.UtcNow - timeSpan;
-        return _sessions.Count(s => s.Value >= threshold);
+        return _anonymousSessions
+            .Count(s => s.Value >= threshold);
     }
-
-    public static int Count => _sessions.Count;
 }

--- a/src/Backend.Core/Web/Context/LoggedInSessionStore.cs
+++ b/src/Backend.Core/Web/Context/LoggedInSessionStore.cs
@@ -10,13 +10,22 @@ public static class LoggedInSessionStore
 
     static LoggedInSessionStore()
     {
-        _cleanupTimer = new System.Timers.Timer(CleanupIntervalMinutes * 60 * 1000); // 10 minutes in milliseconds
-        _cleanupTimer.Elapsed += CleanupOldSessions;
-        _cleanupTimer.AutoReset = true;
+        _cleanupTimer = new System.Timers.Timer(CleanupIntervalMinutes * 60 * 1000)
+        {
+            AutoReset = false
+        };
+        _cleanupTimer.Elapsed += (s, e) =>
+        {
+            try { CleanupOldSessions(); }
+            finally
+            {
+                _cleanupTimer.Start();
+            }
+        };
         _cleanupTimer.Start();
     }
 
-    private static void CleanupOldSessions(object? sender, ElapsedEventArgs e)
+    private static void CleanupOldSessions()
     {
         var cutoffTime = DateTime.UtcNow.AddMinutes(-CleanupIntervalMinutes);
 

--- a/src/Backend.Core/Web/Context/SessionUser.cs
+++ b/src/Backend.Core/Web/Context/SessionUser.cs
@@ -69,7 +69,6 @@ public class SessionUser : IRegisterAsInstancePerLifetime, ISessionUser
     public void Login(User user, PageViewRepo _pageViewRepo)
     {
         _httpContext.Session.ForceInit();
-        LoggedInSessionStore.Add(_httpContext.Session.Id);
         HasBetaAccess = true;
         IsLoggedIn = true;
         _userId = user.Id;

--- a/src/Frontend.Nuxt/pages/maintenance.vue
+++ b/src/Frontend.Nuxt/pages/maintenance.vue
@@ -63,33 +63,33 @@ interface ActiveSessionsResponse {
 }
 
 const questionMethods = ref<MethodData[]>([
-    { url: 'RecalculateAllKnowledgeItems', label: 'Alle Antwortwahrscheinlichkeiten neu berechnen' },
-    { url: 'CalcAggregatedValuesQuestions', label: 'Aggregierte Zahlen aktualisieren' }
+    { url: 'RecalculateAllKnowledgeItems', label: 'Recalculate all answer probabilities' },
+    { url: 'CalcAggregatedValuesQuestions', label: 'Update aggregated numbers' }
 ])
 const cacheMethods = ref<MethodData[]>([
-    { url: 'ClearCache', label: 'Cache leeren' },
+    { url: 'ClearCache', label: 'Clear cache' },
 ])
 const pageMethods = ref<MethodData[]>([
-    { url: 'UpdateCategoryAuthors', label: 'Seitenautoren aktualisieren' }
+    { url: 'UpdateCategoryAuthors', label: 'Update page authors' }
 ])
 const meiliSearchMethods = ref<MethodData[]>([
-    { url: 'MeiliReIndexAllQuestions', label: 'Fragen' },
-    { url: 'MeiliReIndexAllQuestionsCache', label: 'Fragen (Cache)' },
-    { url: 'MeiliReIndexAllPages', label: 'Seiten' },
-    { url: 'MeiliReIndexAllPagesCache', label: 'Seiten (Cache)' },
-    { url: 'MeiliReIndexAllUsers', label: 'Nutzer' },
-    { url: 'MeiliReIndexAllUsersCache', label: 'Nutzer (Cache)' }
+    { url: 'MeiliReIndexAllQuestions', label: 'Questions' },
+    { url: 'MeiliReIndexAllQuestionsCache', label: 'Questions (Cache)' },
+    { url: 'MeiliReIndexAllPages', label: 'Pages' },
+    { url: 'MeiliReIndexAllPagesCache', label: 'Pages (Cache)' },
+    { url: 'MeiliReIndexAllUsers', label: 'Users' },
+    { url: 'MeiliReIndexAllUsersCache', label: 'Users (Cache)' }
 ])
 const userMethods = ref<MethodData[]>([
-    { url: 'UpdateUserReputationAndRankings', label: 'Rankings und Reputation + Aggregates' },
-    { url: 'UpdateUserWishCount', label: 'Wunschwissenzähler aktualisieren' }
+    { url: 'UpdateUserReputationAndRankings', label: 'Rankings and Reputation + Aggregates' },
+    { url: 'UpdateUserWishCount', label: 'Update desired knowledge counter' }
 ])
 const miscMethods = ref<MethodData[]>([
-    { url: 'CheckForDuplicateInteractionNumbers', label: 'Auf Antworten mit selber Guid und InteractionNr checken' }
+    { url: 'CheckForDuplicateInteractionNumbers', label: 'Check for answers with the same Guid and InteractionNr' }
 ])
 const toolsMethods = ref<MethodData[]>([
-    { url: 'Throw500', label: 'Exception werfen' },
-    { url: 'ReloadListFromIgnoreCrawlers', label: 'List von den igniorierten Crawlers neu lade' },
+    { url: 'Throw500', label: 'Throw exception' },
+    { url: 'ReloadListFromIgnoreCrawlers', label: 'Reload list of ignored crawlers' },
     { url: 'CleanUpWorkInProgressQuestions', label: 'Clean up work in progress questions' },
     { url: 'Start100TestJobs', label: 'Start 100 test jobs' },
 
@@ -171,57 +171,57 @@ async function removeAdminRights() {
             <div class="main-content">
                 <div class="col-xs-12"
                     v-if="isAdmin && userStore.isAdmin && antiForgeryToken != null && antiForgeryToken?.length > 0">
-                    <h1>Adminseite</h1>
+                    <h1>Admin Page</h1>
                     <div class="row">
                         <div class="alert alert-warning alert-dismissible" role="alert" v-if="resultMsg.length > 0">
                             <button type="button" class="close" data-dismiss="alert" aria-label="Close"
                                 @click.prevent="resultMsg = ''"><span aria-hidden="true">&times;</span></button>
                             {{ resultMsg }}
                         </div>
-                        <MaintenanceSection title="Metriken" :methods="[]">
+                        <MaintenanceSection title="Metrics" :methods="[]">
                             <div class="custom-container">
                                 <NuxtLink to="/Metriken" class="memo-button btn btn-primary">
-                                    Übersicht aufrufen
+                                    View Overview
                                 </NuxtLink>
                             </div>
                         </MaintenanceSection>
-                        <MaintenanceSection title="Fragen" :methods="questionMethods" @method-clicked="handleClick"
+                        <MaintenanceSection title="Questions" :methods="questionMethods" @method-clicked="handleClick"
                             :icon="['fas', 'retweet']" />
                         <MaintenanceSection title="Cache" :methods="cacheMethods" @method-clicked="handleClick"
                             :icon="['fas', 'retweet']" />
-                        <MaintenanceSection title="Seiten" :methods="pageMethods" @method-clicked="handleClick"
+                        <MaintenanceSection title="Pages" :methods="pageMethods" @method-clicked="handleClick"
                             :icon="['fas', 'retweet']" />
-                        <MaintenanceSection title="Suche MeiliSearch" :methods="meiliSearchMethods"
-                            description="Alle für Suche neu indizieren:" @method-clicked="handleClick"
+                        <MaintenanceSection title="Search MeiliSearch" :methods="meiliSearchMethods"
+                            description="Re-index all for search:" @method-clicked="handleClick"
                             :icon="['fas', 'retweet']" />
-                        <MaintenanceSection title="Nutzer" :methods="userMethods" @method-clicked="handleClick"
+                        <MaintenanceSection title="Users" :methods="userMethods" @method-clicked="handleClick"
                             :icon="['fas', 'retweet']">
                             <div class="active-users-info">
-                                <h4>Aktive Sitzungen</h4>
+                                <h4>Active Sessions</h4>
                                 <ul>
-                                    <li>Angemeldet: {{ loggedInUserCount }} (letzte 5 Minuten)</li>
-                                    <li>Anonym: {{ anonymousUserCount }} (letzte Minute)</li>
+                                    <li>Logged in: {{ loggedInUserCount }} (last 5 minutes)</li>
+                                    <li>Anonymous: {{ anonymousUserCount }} (last minute)</li>
                                 </ul>
                             </div>
                             <div class="delete-user-container">
-                                <h4>Nutzer löschen (ID)</h4>
+                                <h4>Delete User (ID)</h4>
                                 <div class="delete-user-input">
                                     <input v-model="userIdToDelete" />
                                     <button @click="deleteUser" class="memo-button btn btn-primary">
-                                        Nutzer Löschen
+                                        Delete User
                                     </button>
                                 </div>
                             </div>
                         </MaintenanceSection>
-                        <MaintenanceSection title="Sonstige" :methods="miscMethods" @method-clicked="handleClick"
+                        <MaintenanceSection title="Miscellaneous" :methods="miscMethods" @method-clicked="handleClick"
                             :icon="['fas', 'retweet']" />
                         <MaintenanceSection title="Tools" :methods="toolsMethods" @method-clicked="handleClick"
                             :icon="['fas', 'hammer']" />
                         <div class="remove-admin-rights-section col-xs-12 col-lg-6">
-                            <h3>Adminrechte abgeben</h3>
+                            <h3>Remove Admin Rights for current user</h3>
                             <div>
                                 <button @click="removeAdminRights" class="memo-button btn btn-primary">
-                                    Adminrechte abgeben
+                                    Remove Admin Rights for current user
                                 </button>
                             </div>
                         </div>

--- a/src/Frontend.Nuxt/pages/maintenance.vue
+++ b/src/Frontend.Nuxt/pages/maintenance.vue
@@ -42,16 +42,14 @@ const { data: activeSessionsResult } = await useFetch<ActiveSessionsResponse>('/
     },
 })
 
-const activeUserCount = ref(0)
+const loggedInUserCount = ref(0)
+const anonymousUserCount = ref(0)
 watchEffect(() => {
-    if (activeSessionsResult.value)
-        activeUserCount.value = activeSessionsResult.value.activeUserCount
-})
+    if (activeSessionsResult.value) {
+        loggedInUserCount.value = activeSessionsResult.value.loggedInUserCount;
+        anonymousUserCount.value = activeSessionsResult.value.anonymousUserCount;
+    }
 
-const activeSessions = ref<string[]>([])
-watchEffect(() => {
-    if (activeSessionsResult.value)
-        activeSessions.value = activeSessionsResult.value.sessions
 })
 
 interface MethodData {
@@ -60,9 +58,10 @@ interface MethodData {
 }
 
 interface ActiveSessionsResponse {
-    activeUserCount: number
-    sessions: string[]
+    loggedInUserCount: number,
+    anonymousUserCount: number
 }
+
 const questionMethods = ref<MethodData[]>([
     { url: 'RecalculateAllKnowledgeItems', label: 'Alle Antwortwahrscheinlichkeiten neu berechnen' },
     { url: 'CalcAggregatedValuesQuestions', label: 'Aggregierte Zahlen aktualisieren' }
@@ -198,10 +197,10 @@ async function removeAdminRights() {
                         <MaintenanceSection title="Nutzer" :methods="userMethods" @method-clicked="handleClick"
                             :icon="['fas', 'retweet']">
                             <div class="active-users-info">
-                                <h4>Aktive Sitzungen (5 Minuten)</h4>
-                                <p>Gesamt: {{ activeUserCount }}</p>
+                                <h4>Aktive Sitzungen</h4>
                                 <ul>
-                                    <li v-for="session in activeSessions" :key="session">{{ session }}</li>
+                                    <li>Angemeldet: {{ loggedInUserCount }} (letzte 5 Minuten)</li>
+                                    <li>Anonym: {{ anonymousUserCount }} (letzte Minute)</li>
                                 </ul>
                             </div>
                             <div class="delete-user-container">


### PR DESCRIPTION
## Summary
- count sessions in the `LoggedInSessionStore` by last activity
- touch session timestamp via middleware rather than getters
- expose combined session info via `GetActiveSessions` API
- show active user count and recent sessions on the maintenance page

## Testing
- `dotnet test --no-build` *(fails: command not found)*